### PR TITLE
support_import - Support imported kea config in json

### DIFF
--- a/templates/kea-dhcp-ddns.conf.j2
+++ b/templates/kea-dhcp-ddns.conf.j2
@@ -1,3 +1,3 @@
 {% if kea_ddns_config %}
-{{ kea_ddns_config | to_nice_json }}
+{{ kea_ddns_config | to_nice_json | regex_replace('(")(<\?include )(.*)(\?>)(")', '\\2"\\3" \\4') }}
 {% endif %}

--- a/templates/kea-dhcp4.conf.j2
+++ b/templates/kea-dhcp4.conf.j2
@@ -1,3 +1,3 @@
 {% if kea_dhcp4_config %}
-{{ kea_dhcp4_config | to_nice_json }}
+{{ kea_dhcp4_config | to_nice_json | regex_replace('(")(<\?include )(.*)(\?>)(")', '\\2"\\3" \\4') }}
 {% endif %}

--- a/templates/kea-dhcp6.conf.j2
+++ b/templates/kea-dhcp6.conf.j2
@@ -1,3 +1,3 @@
 {% if kea_dhcp6_config %}
-{{ kea_dhcp6_config | to_nice_json }}
+{{ kea_dhcp6_config | to_nice_json | regex_replace('(")(<\?include )(.*)(\?>)(")', '\\2"\\3" \\4') }}
 {% endif %}


### PR DESCRIPTION
This gives the ability to use `include` in the config files.
Using `include` creates invalid json file but valid kea config, so using  `to_nice_json` only is not enough.

With this code you can have config like:
```
- subnet: 10.0.0.0/20
  reservations: "<?include /etc/kea/conf.d/generated_reservations.json?>"
```